### PR TITLE
Add cmake module for appindicator + standard icon name + build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,16 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR) # target_link_directories
 
 project(tray C)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
 
 # Generate 'compile_commands.json' for clang_complete
+set(CMAKE_COLOR_MAKEFILE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+
+find_package (PkgConfig REQUIRED)
+
 
 file(GLOB SRCS
         ${CMAKE_CURRENT_LIST_DIR}/*.h
@@ -20,8 +26,7 @@ else()
 			find_library(COCOA Cocoa REQUIRED)
 			list(APPEND SRCS ${CMAKE_CURRENT_SOURCE_DIR}/tray_darwin.m)
 		else()
-			FIND_PACKAGE(PkgConfig)
-			PKG_CHECK_MODULES(APPINDICATOR REQUIRED appindicator3-0.1)
+			find_package(APPINDICATOR REQUIRED)
 			list(APPEND SRCS ${CMAKE_CURRENT_SOURCE_DIR}/tray_linux.c)
 		endif()
 	endif()
@@ -36,15 +41,15 @@ if(WIN32)
 	endif()
 else()
         if(UNIX)
-                if(APPLE)
-			target_compile_definitions(tray PRIVATE TRAY_APPKIT=1)
-			target_link_libraries(tray PRIVATE ${COCOA})
-                else()
-			target_compile_options(tray PRIVATE ${APPINDICATOR_CFLAGS})
-			target_link_directories(tray PRIVATE ${APPINDICATOR_LIBRARY_DIRS})
-			target_compile_definitions(tray PRIVATE TRAY_APPINDICATOR=1)
-			target_link_libraries(tray PRIVATE ${APPINDICATOR_LIBRARIES})
-                endif()
+			if(APPLE)
+				target_compile_definitions(tray PRIVATE TRAY_APPKIT=1)
+				target_link_libraries(tray PRIVATE ${COCOA})
+            else()
+				target_compile_options(tray PRIVATE ${APPINDICATOR_CFLAGS})
+				target_link_directories(tray PRIVATE ${APPINDICATOR_LIBRARY_DIRS})
+				target_compile_definitions(tray PRIVATE TRAY_APPINDICATOR=1)
+				target_link_libraries(tray PRIVATE ${APPINDICATOR_LIBRARIES})
+			endif()
         endif()
 endif()
 

--- a/cmake/FindAPPINDICATOR.cmake
+++ b/cmake/FindAPPINDICATOR.cmake
@@ -1,0 +1,29 @@
+# Remmina - The GTK+ Remote Desktop Client
+#
+# Copyright (C) 2011 Marc-Andre Moreau
+# Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli, Giovanni Panozzo
+# Copyright (C) 2016-2023 Antenore Gatta, Giovanni Panozzo
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA  02110-1301, USA.
+
+include(FindPackageHandleStandardArgs)
+
+PKG_CHECK_MODULES(APPINDICATOR ayatana-appindicator3-0.1)
+IF( APPINDICATOR_FOUND )
+    SET(HAVE_AYATANAAPPINDICATOR 1)
+ENDIF()
+
+mark_as_advanced(APPINDICATOR_INCLUDE_DIR APPINDICATOR_LIBRARY)

--- a/example.c
+++ b/example.c
@@ -12,8 +12,8 @@
 #include "tray.h"
 
 #if TRAY_APPINDICATOR
-#define TRAY_ICON1 "indicator-messages"
-#define TRAY_ICON2 "indicator-messages-new"
+#define TRAY_ICON1 "mail-message-new"
+#define TRAY_ICON2 "mail-message-new"
 #elif TRAY_APPKIT
 #define TRAY_ICON1 "icon.png"
 #define TRAY_ICON2 "icon.png"

--- a/tray_linux.c
+++ b/tray_linux.c
@@ -1,6 +1,7 @@
-#include <gtk/gtk.h>
-#include <libappindicator/app-indicator.h>
 #include "tray.h"
+#include <string.h>
+#include <stddef.h>
+#include <libayatana-appindicator/app-indicator.h>
 
 #define TRAY_APPINDICATOR_ID "tray-id"
 


### PR DESCRIPTION
This PR has multiple changes not related to each others, sorry:

- Change icon name to FreeDesktop standard ones (linux)
- Use of Ayatana instead of appindicator (fix Ubuntu 22.10 build)
- Exported CMake APPINDICATOR library in external module (allow future hacks for other Linux distributions if needed)
- Add somes standard includes