### PR TITLE
Re-add the tray icon if Explorer restarts

### DIFF
--- a/tray_windows.c
+++ b/tray_windows.c
@@ -10,6 +10,7 @@ static WNDCLASSEX wc;
 static NOTIFYICONDATA nid;
 static HWND hwnd;
 static HMENU hmenu = NULL;
+static UINT wm_taskbarcreated;
 
 static LRESULT CALLBACK _tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wparam,
                                        LPARAM lparam) {
@@ -47,6 +48,12 @@ static LRESULT CALLBACK _tray_wnd_proc(HWND hwnd, UINT msg, WPARAM wparam,
     }
     break;
   }
+
+  if (msg == wm_taskbarcreated) {
+    Shell_NotifyIcon(NIM_ADD, &nid);
+    return 0;
+  }
+
   return DefWindowProc(hwnd, msg, wparam, lparam);
 }
 
@@ -83,6 +90,8 @@ static HMENU _tray_menu(struct tray_menu *m, UINT *id) {
 }
 
 int tray_init(struct tray *tray) {
+  wm_taskbarcreated = RegisterWindowMessage("TaskbarCreated");
+
   memset(&wc, 0, sizeof(wc));
   wc.cbSize = sizeof(WNDCLASSEX);
   wc.lpfnWndProc = _tray_wnd_proc;


### PR DESCRIPTION
When Explorer restarts, it's the application's responsibility to re-add any notification icons that were present. To trigger this, Explorer will send a global TaskbarCreated message. Details on this process are available on MSDN here: https://learn.microsoft.com/en-us/windows/win32/shell/taskbar#taskbar-creation-notification

This PR introduces handling of this message in `_tray_wnd_proc()` to prevent the tray icon from disappearing after an Explorer crash/restart.

The existing bug can be reproduced as follows:
1. Create a tray icon using `tray_init()` and confirm presence in the notification area.
2. Open Task Manager, right click "Windows Explorer" on the Processes tab, and select Restart.
3. After Explorer starts up again, check for the presence of the tray icon again.

Prior to this PR, the tray icon will not reappear. With this change, it reappears properly.