### PR TITLE
Disable find_package(PkgConfig) on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 set(CMAKE_COLOR_MAKEFILE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-
-find_package (PkgConfig REQUIRED)
-
+if(NOT WIN32)
+    find_package (PkgConfig REQUIRED)
+endif()
 
 file(GLOB SRCS
         ${CMAKE_CURRENT_LIST_DIR}/*.h


### PR DESCRIPTION
Compile using `mscv` or `mingw`, the problem occurs:

```shell
❯ cmake ..
-- Building for: Visual Studio 17 2022
-- Selecting Windows SDK version 10.0.22621.0 to target Windows 6.2.9200.
-- The C compiler identification is MSVC 19.38.33134.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.38.33130/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at D:/Program Files/Mingw64/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
Call Stack (most recent call first):
  D:/Program Files/Mingw64/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  D:/Program Files/Mingw64/share/cmake-3.26/Modules/FindPkgConfig.cmake:99 (find_package_handle_standard_args)
  CMakeLists.txt:13 (find_package)
```

```shell
❯ cmake -G "MinGW Makefiles" ..
-- The C compiler identification is GNU 13.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/Program Files/Mingw64/bin/gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
CMake Error at D:/Program Files/Mingw64/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
Call Stack (most recent call first):
  D:/Program Files/Mingw64/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  D:/Program Files/Mingw64/share/cmake-3.26/Modules/FindPkgConfig.cmake:99 (find_package_handle_standard_args)
  CMakeLists.txt:13 (find_package)


-- Configuring incomplete, errors occurred!
```

Except for `msys2`, most other `mingw` versions do not include `pkg-config`.