### PR TITLE
fix: windows can not quit when call `exit`

### DIFF
--- a/tray_windows.c
+++ b/tray_windows.c
@@ -135,9 +135,9 @@ int tray_init(struct tray *tray) {
 int tray_loop(int blocking) {
   MSG msg;
   if (blocking) {
-    GetMessage(&msg, hwnd, 0, 0);
+    GetMessage(&msg, NULL, 0, 0);
   } else {
-    PeekMessage(&msg, hwnd, 0, 0, PM_REMOVE);
+    PeekMessage(&msg, NULL, 0, 0, PM_REMOVE);
   }
   if (msg.message == WM_QUIT) {
     return -1;


### PR DESCRIPTION
Windows platform getmessage and peekmessage must use NULL to receive the WM_QUIT message